### PR TITLE
Square grid changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -281,13 +281,13 @@ module.exports = function (grunt) {
         concatSrc = 'src/**/*.js';
       }
 
-      grunt.task.run(['clean', 'lint', 'ngtemplates', 'concat', 'ngAnnotate', 'uglify:build', 'cssmin', 'copymain', 'ngdocs', 'clean:templates']);
+      grunt.task.run(['clean', 'test', 'ngtemplates', 'concat', 'ngAnnotate', 'uglify:build', 'cssmin', 'copymain', 'ngdocs', 'clean:templates']);
     });
 
     // Runs all the tasks of build with the exception of tests
     grunt.registerTask('deploy', 'Prepares the project for deployment. Does not run unit tests', function () {
       var concatSrc = 'src/**/*.js';
-      grunt.task.run(['clean', 'lint', 'ngtemplates', 'concat', 'ngAnnotate', 'uglify:build', 'cssmin', 'copymain', 'ngdocs', 'clean:templates']);
+      grunt.task.run(['clean', 'lint', 'test', 'ngtemplates', 'concat', 'ngAnnotate', 'uglify:build', 'cssmin', 'copymain', 'ngdocs', 'clean:templates']);
     });
 
     grunt.registerTask('default', ['build']);

--- a/src/charts/heatmap/heatmap.directive.js
+++ b/src/charts/heatmap/heatmap.directive.js
@@ -290,6 +290,7 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         var data = scope.data;
         var color = d3.scale.threshold().domain(scope.thresholds).range(scope.heatmapColorPattern);
         var rangeTooltip = d3.scale.threshold().domain(scope.thresholds).range(scope.rangeTooltips);
+        var groups;
         var blocks;
         var fillSize = blockSize - scope.padding;
         var highlightBlock = function (block, active) {
@@ -307,11 +308,8 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         };
 
         var svg = window.d3.select(thisComponent);
-        var groups;
         svg.selectAll('*').remove();
         groups = svg.selectAll('g').data(data).enter().append('g');
-        // blocks = svg.selectAll('rect').data(data).enter().append('rect');
-        // blocks.attr('x', function (d, i) {
         groups.append('rect').attr('x', function (d, i) {
           return Math.floor(i / numberOfRows) * blockSize;
         }).attr('y', function (d, i) {

--- a/src/charts/heatmap/heatmap.directive.js
+++ b/src/charts/heatmap/heatmap.directive.js
@@ -163,7 +163,8 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
       rangeHoverSize: '@',
       rangeTooltips: '=?',
       includeTooltipInsideBox: '=?',
-      tooltipInsideBoxClass: '=?'
+      tooltipInsideBoxClass: '=?',
+      useSquareGrid: '=?'
     },
     templateUrl: 'charts/heatmap/heatmap.html',
     controller: function ($scope) {
@@ -172,6 +173,7 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
       var legendLabelDefaults = ['< 70%', '70-80%' ,'80-90%', '> 90%'];
       var rangeTooltipDefaults = ['< 70%', '70-80%' ,'80-90%', '> 90%'];
       var heightDefault = 200;
+      var absoluteMaxBlockSize = 128;
 
       //Allow overriding of defaults
       if ($scope.maxBlockSize === undefined || isNaN($scope.maxBlockSize)) {
@@ -180,8 +182,8 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         $scope.maxSize = parseInt($scope.maxBlockSize);
         if ($scope.maxSize < 5) {
           $scope.maxSize = 5;
-        } else if ($scope.maxSize > 50) {
-          $scope.maxSize = 50;
+        } else if ($scope.maxSize > absoluteMaxBlockSize) {
+          $scope.maxSize = absoluteMaxBlockSize;
         }
       }
 
@@ -223,10 +225,11 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
       $scope.height = $scope.height || heightDefault;
       $scope.showLegend = $scope.showLegend || ($scope.showLegend === undefined);
       $scope.loadingDone = false;
+      $scope.useSquareGrid = $scope.useSquareGrid === undefined ? true : $scope.useSquareGrid === "true";
     },
     link: function (scope, element, attrs) {
       var thisComponent = element[0].querySelector('.heatmap-pf-svg');
-      var containerWidth, containerHeight, blockSize, numberOfRows;
+      var containerWidth, containerHeight, blockSize, numberOfRows, numberOfCols;
 
       var setStyles = function () {
         scope.containerStyles = {
@@ -240,28 +243,35 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         containerWidth = parentContainer.clientWidth;
         containerHeight = parentContainer.clientHeight;
         blockSize = determineBlockSize();
-
-        if ((blockSize - scope.padding) > scope.maxSize) {
-          blockSize = scope.padding + scope.maxSize;
-
-          // Attempt to square off the area, check if square fits
-          numberOfRows = Math.ceil(Math.sqrt(scope.data.length));
-          if (blockSize * numberOfRows > containerWidth ||
-              blockSize * numberOfRows > containerHeight) {
-            numberOfRows = (blockSize === 0) ? 0 : Math.floor(containerHeight / blockSize);
-          }
-        } else if ((blockSize - scope.padding) < scope.minSize) {
-          blockSize = scope.padding + scope.minSize;
-
-          // Attempt to square off the area, check if square fits
-          numberOfRows = Math.ceil(Math.sqrt(scope.data.length));
-          if (blockSize * numberOfRows > containerWidth ||
-              blockSize * numberOfRows > containerHeight) {
-            numberOfRows = (blockSize === 0) ? 0 : Math.floor(containerHeight / blockSize);
-          }
+        if (scope.useSquareGrid) {
+          numberOfRows = determineNumRows();
         } else {
-          numberOfRows = (blockSize === 0) ? 0 : Math.floor(containerHeight / blockSize);
+          numberOfCols = determineNumCols();
         }
+      };
+
+      var determineNumRows = function () {
+        var numRows;
+        if (blockSize === 0) {
+          return 0;
+        }
+
+        // Attempt to square off the area, check if square fits.
+        numRows = Math.ceil(Math.sqrt(scope.data.length));
+        if (blockSize * numRows > containerHeight ||
+           blockSize * numRows > containerWidth) {
+          numRows = Math.floor(containerHeight / blockSize);
+        }
+
+        return numRows;
+      };
+
+      var determineNumCols = function () {
+        if (blockSize === 0) {
+          return 0;
+        }
+
+        return Math.floor(containerWidth / blockSize);
       };
 
       var determineBlockSize = function () {
@@ -271,6 +281,7 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         var px = Math.ceil(Math.sqrt(n * x / y));
         var py = Math.ceil(Math.sqrt(n * y / x));
         var sx, sy;
+        var optimalSize;
 
         if (Math.floor(px * y / x) * px < n) {
           sx = y / Math.ceil(px * y / x);
@@ -283,7 +294,30 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         } else {
           sy = y / py;
         }
-        return Math.max(sx, sy);
+        optimalSize = Math.max(sx, sy);
+
+        // Correct optimal size if it does not fit.
+        if ((optimalSize - scope.padding) > scope.maxSize) {
+          return scope.padding + scope.maxSize;
+        } else if ((optimalSize - scope.padding) < scope.minSize) {
+          return scope.padding + scope.minSize;
+        }
+
+        return optimalSize;
+      };
+
+      var getXValue = function (d, i) {
+        if (scope.useSquareGrid) {
+          return Math.floor(i / numberOfRows) * blockSize;
+        }
+        return i % numberOfCols * blockSize;
+      };
+
+      var getYValue = function (d, i) {
+        if (scope.useSquareGrid) {
+          return i % numberOfRows * blockSize;
+        }
+        return Math.floor(i / numberOfCols) * blockSize;
       };
 
       var redraw = function () {
@@ -310,11 +344,10 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
         var svg = window.d3.select(thisComponent);
         svg.selectAll('*').remove();
         groups = svg.selectAll('g').data(data).enter().append('g');
-        groups.append('rect').attr('x', function (d, i) {
-          return Math.floor(i / numberOfRows) * blockSize;
-        }).attr('y', function (d, i) {
-          return i % numberOfRows * blockSize;
-        }).attr('width', fillSize).attr('height', fillSize).style('fill', function (d) {
+        groups.append('rect'
+        ).attr('x', getXValue
+        ).attr('y', getYValue
+        ).attr('width', fillSize).attr('height', fillSize).style('fill', function (d) {
           return color(d.value);
         }).attr('uib-tooltip-html', function (d, i) { //tooltip-html is throwing an exception
           if (scope.rangeOnHover && fillSize <= scope.rangeHoverSize) {
@@ -334,9 +367,9 @@ angular.module('patternfly.charts').directive('pfHeatmap', function ($compile, $
           }).text(function (d) {
             return d.tooltip;
           }).attr("x", function (d, i) {
-            return (Math.floor(i / numberOfRows) * blockSize) + 3;
+            return getXValue(d, i) + 3;
           }).attr("y", function (d, i) {
-            return (i % numberOfRows * blockSize) + 10;
+            return getYValue(d, i) + 10;
           });
 
           // forcing text to wrap inside each box

--- a/test/charts/heatmap/heatmap.spec.js
+++ b/test/charts/heatmap/heatmap.spec.js
@@ -48,7 +48,7 @@ describe('Directive: pfHeatmap', function() {
   it("should set color and tooltip of the block based on defaults", function() {
     element = compileChart('<div pf-heatmap chart-title="title" data="data"></div>',$scope);
 
-    block = angular.element(element).find('.heatmap-pf-svg').children().first();
+    block = angular.element(element).find('.heatmap-pf-svg').children().first().children().first();
     tooltip = block.attr('uib-tooltip-html');
 
     expect(tooltip).toBe("'Node 8 : My OpenShift Provider<br>96% : 96 Used of 100 Total<br>4 Available'");
@@ -65,7 +65,7 @@ describe('Directive: pfHeatmap', function() {
 
     element = compileChart('<div pf-heatmap chart-title="title" data="data" legend-labels="legendLabels" heatmap-color-pattern="heatmapColorPattern" thresholds="thresholds"></div>',$scope);
 
-    block = angular.element(element).find('.heatmap-pf-svg').children().first();
+    block = angular.element(element).find('.heatmap-pf-svg').children().first().children().first();
 
     color = block.attr('style');
 
@@ -79,7 +79,7 @@ describe('Directive: pfHeatmap', function() {
     $scope.heatmapColorPattern = ['#d4f0fa', '#F9D67A', '#EC7A08', '#CE0000', '#ff0000'];
 
     element = compileChart('<div pf-heatmap chart-title="title" data="data" legend-labels="legendLabels" heatmap-color-pattern="heatmapColorPattern" thresholds="thresholds"></div>',$scope);
-    block = angular.element(element).find('.heatmap-pf-svg').children().first();
+    block = angular.element(element).find('.heatmap-pf-svg').children().first().children().first();
     color = block.attr('style');
 
     var result = color.trim() == 'fill: #ce0000;' || color.trim() == 'fill: rgb(206, 0, 0);';


### PR DESCRIPTION
This change allows you to toggle off the "squareness" of the heatmap directive. If the option is unset, then the heatmap will take up the horizontal space first instead of prioritizing making a square.